### PR TITLE
import sys for sys.exit() on line 118

### DIFF
--- a/PiDataCenter/picluster.py
+++ b/PiDataCenter/picluster.py
@@ -16,6 +16,7 @@ import random
 import re
 import requests
 import socket
+import sys
 import time
 import uuid
 import platform


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/microsoft/ELL-PiDataCenter on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./PiDataCenter/picluster.py:117:13: F821 undefined name 'sys'
            sys.exit(1)
            ^
1     F821 undefined name 'sys'
1
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree